### PR TITLE
thundergod desktop notifications

### DIFF
--- a/lib/paul_dix_thundergod.rb
+++ b/lib/paul_dix_thundergod.rb
@@ -4,7 +4,7 @@ module PaulDixThundergod
   def self.play
     COMMANDS_TO_TRY.each do |command|
       if system("which #{command}")
-        `#{command} #{File.dirname(__FILE__)}/paul_dix_thundergod/support/deploy_sound.mp3 &`
+        `#{command} #{asset_path("deploy_sound.mp3")} &`
         break
       end
     end
@@ -13,10 +13,15 @@ module PaulDixThundergod
   def self.rollback
     COMMANDS_TO_TRY.each do |command|
       if system("which #{command}")
-        `#{command} #{File.dirname(__FILE__)}/paul_dix_thundergod/support/rollback_sound.mp3 &`
+        `#{command} #{asset_path("rollback_sound.mp3")} &`
         break
       end
     end
   end
 
+  private
+
+  def self.asset_path(filename)
+    File.join(File.dirname(__FILE__), "paul_dix_thundergod/support", filename)
+  end
 end

--- a/lib/paul_dix_thundergod.rb
+++ b/lib/paul_dix_thundergod.rb
@@ -2,6 +2,10 @@ module PaulDixThundergod
   COMMANDS_TO_TRY = %w[afplay play omxplayer]
 
   def self.play
+    if system("which notify-send")
+      `notify-send -i #{asset_path("thundergod.png")} "DEPLOY" "Good luck and godspeed."`
+    end
+
     COMMANDS_TO_TRY.each do |command|
       if system("which #{command}")
         `#{command} #{asset_path("deploy_sound.mp3")} &`


### PR DESCRIPTION
Do you like calling down the thunder? Are you on a linux machine? Are you running a desktop that is compliant with the [Desktop Notifications Specification](https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html)? Is your name Mike?

Then you'll love this one quick trick to make Paul Dix Thundergod appear in your desktop notifications.

---

If you have `notify-send` installed, it'll get called when the sweet sweet thunder is called down.

![image](https://user-images.githubusercontent.com/8207/94969761-4f4c2b80-04d1-11eb-9f2f-5f594232f510.png)
