### PR TITLE
Insert Dix, Don't wait for Dix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,34 @@
 
 ## How do I use Paul Dix: Thundergod
 
-1.  Slow down. You do not use Paul Dix. Paul Dix USES YOU.
+* Slow down:
 
-2.  Install this gem
-      `gem install paul_dix_thundergod`
-3.  Write deploy task like (capistrano example):
+  You do not use Paul Dix.
 
-        task :play_sound do
-          PaulDixThundergod.play
+  Paul Dix USES YOU.
+
+* Install this gem
+
+        group :development do
+          gem "paul_dix_thundergod", require: false
         end
 
-4.  Hook the task into your deployment script (capistrano example):
-      `before "deploy", "deploy:play_sound"`
+* Write a deploy task like: (capistrano example)
 
-5.  The gem also comes with with a PaulDixThundergod.rollback, a method worth hooking into your @before "deploy:rollback"@
+        require 'paul_dix_thundergod'
+
+        namespace :deploy do
+          task :play_sound do
+            PaulDixThundergod.play
+          end
+        end
+
+* Hook the task into your deployment script (capistrano example):
+
+        before "deploy", "deploy:play_sound"
+
+* The gem also comes with with a `PaulDixThundergod.rollback`, a method worth hooking into your `before "deploy:rollback"`
+
 
 ## Bringing Thunder From the Command Line
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 * Hook the task into your deployment script (capistrano example):
 
         before "deploy", "deploy:play_sound"
+        before "deploy:migrations", "deploy:play_sound"
+
 
 * The gem also comes with with a `PaulDixThundergod.rollback`, a method worth hooking into your `before "deploy:rollback"`
 

--- a/README.md
+++ b/README.md
@@ -17,31 +17,27 @@
 
   Paul Dix USES YOU.
 
-* Install this gem
+* use the deploy sounds:
 
-        group :development do
-          gem "paul_dix_thundergod", require: false
-        end
+Add it to your `Gemfile`:
 
-* Write a deploy task like: (capistrano example)
+```
+group :development do
+  gem "paul_dix_thundergod", require: false
+end
+```
 
-        require 'paul_dix_thundergod'
+require it in `config/deploy.rb`:
 
-        namespace :deploy do
-          task :play_sound do
-            PaulDixThundergod.play
-          end
-        end
+```
+require 'paul_dix_thundergod/deploy_sounds'
+```
 
-* Hook the task into your deployment script (capistrano example):
+Then try a deploy with `cap deploy` or `cap deploy:migrations`.
 
-        before "deploy", "deploy:play_sound"
-        before "deploy:migrations", "deploy:play_sound"
-
-
-* The gem also comes with with a `PaulDixThundergod.rollback`, a method worth hooking into your `before "deploy:rollback"`
+* The gem also comes with with a bonus rollback sound.
 
 
 ## Bringing Thunder From the Command Line
 
-The gem comes with a bin so you can just type 'paul_dix_thundergod' whenever you want!
+The gem comes with a bin so you can just type `paul_dix_thundergod` whenever you want!

--- a/lib/paul_dix_thundergod.rb
+++ b/lib/paul_dix_thundergod.rb
@@ -8,7 +8,7 @@ module PaulDixThundergod
 
     COMMANDS_TO_TRY.each do |command|
       if system("which #{command}")
-        `#{command} #{asset_path("deploy_sound.mp3")} &`
+        spawn("#{command} #{asset_path("deploy_sound.mp3")}")
         break
       end
     end
@@ -17,7 +17,7 @@ module PaulDixThundergod
   def self.rollback
     COMMANDS_TO_TRY.each do |command|
       if system("which #{command}")
-        `#{command} #{asset_path("rollback_sound.mp3")} &`
+        spawn("#{command} #{asset_path("rollback_sound.mp3")}")
         break
       end
     end

--- a/lib/paul_dix_thundergod/deploy_sounds.rb
+++ b/lib/paul_dix_thundergod/deploy_sounds.rb
@@ -1,0 +1,19 @@
+# require 'paul_dix_thundergod'
+
+Capistrano::Configuration.instance(:must_exist).load do
+  namespace :deploy do
+    desc "Play Deploy Sound"
+    task :play_deploy_sound do
+      PaulDixThundergod.play
+    end
+
+    desc "Play Rollback sound"
+    task :play_rollback_sound do
+      PaulDixThundergod.rollback
+    end
+  end
+
+  before "deploy", "deploy:play_deploy_sound"
+  before "deploy:migrations", "deploy:play_deploy_sound"
+  before "deploy:rollback", "deploy:play_rollback_sound"
+end


### PR DESCRIPTION
Two patches:

* Insert Dix automatically into the cap file.  Just `require 'paul_dix_thundergod/deploy_sounds'` at the top of your `deploy.rb` and thundergod plays with `deploy`, `deploy:migrations`, and `deploy:rollback`.  You no longer need to hook into it explicitly.

* thundergod won't wait: use spawn instead of backtick since you're eager for Dix and don't want to wait for it.